### PR TITLE
PDF-Import S-Broker bis März 2015

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/Messages.java
@@ -564,6 +564,7 @@ public class Messages extends NLS
     public static String LabelLevelNameNumber;
     public static String LabelLevelNumber;
     public static String LabelLinkedToPortfolioReport;
+    public static String LabelLinkToPortfolioReportNet;
     public static String LabelNamePlusCopy;
     public static String LabelNet;
     public static String LabelNewClassification;

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/StartupAddon.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/addons/StartupAddon.java
@@ -36,6 +36,7 @@ import name.abuchen.portfolio.ui.log.LogEntryCache;
 import name.abuchen.portfolio.ui.update.UpdateHelper;
 import name.abuchen.portfolio.ui.util.ProgressMonitorFactory;
 import name.abuchen.portfolio.ui.util.RecentFilesCache;
+import name.abuchen.portfolio.ui.util.swt.ActiveShell;
 
 @SuppressWarnings("restriction")
 public class StartupAddon
@@ -201,5 +202,11 @@ public class StartupAddon
         registry.put(Dialog.DLG_IMG_MESSAGE_ERROR, Images.ERROR.descriptor());
         registry.put(Dialog.DLG_IMG_MESSAGE_WARNING, Images.WARNING.descriptor());
         registry.put(Dialog.DLG_IMG_MESSAGE_INFO, Images.INFO.descriptor());
+    }
+
+    @PostConstruct
+    public void setupActiveShellTracker()
+    {
+        ActiveShell.get();
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/AbstractDropAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/AbstractDropAdapter.java
@@ -1,0 +1,153 @@
+package name.abuchen.portfolio.ui.dnd;
+
+import java.util.Objects;
+
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetAdapter;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.widgets.Control;
+
+// inspired by the Eclipse Marketplace Client
+// https://github.com/eclipse/epp.mpc/blob/master/org.eclipse.epp.mpc.ui/src/org/eclipse/epp/internal/mpc/ui/wizards/MarketplaceDropAdapter.java
+/* package */ abstract class AbstractDropAdapter extends DropTargetAdapter
+{
+    private final Transfer transfer;
+
+    public AbstractDropAdapter(Transfer transfer, Control control)
+    {
+        this.transfer = Objects.requireNonNull(transfer);
+        attach(control);
+    }
+
+    private void attach(Control control)
+    {
+        DropTarget dropTarget = findDropTarget(control);
+
+        if (dropTarget != null)
+        {
+            registerWithExistingTarget(dropTarget);
+        }
+        else
+        {
+            dropTarget = new DropTarget(control, DND.DROP_MOVE | DND.DROP_COPY | DND.DROP_LINK | DND.DROP_DEFAULT);
+            dropTarget.setTransfer(this.transfer);
+        }
+
+        dropTarget.addDropListener(this);
+    }
+
+    private void registerWithExistingTarget(DropTarget target)
+    {
+        Transfer[] transfers = target.getTransfer();
+        boolean exists = false;
+        if (transfers != null)
+        {
+            for (Transfer t : transfers)
+            {
+                if (t.equals(this.transfer))
+                {
+                    exists = true;
+                    break;
+                }
+            }
+            if (!exists)
+            {
+                Transfer[] newTransfers = new Transfer[transfers.length + 1];
+                System.arraycopy(transfers, 0, newTransfers, 0, transfers.length);
+                newTransfers[transfers.length] = this.transfer;
+                target.setTransfer(newTransfers);
+            }
+        }
+    }
+
+    private DropTarget findDropTarget(Control control)
+    {
+        if (control.isDisposed())
+            return null;
+        Object object = control.getData(DND.DROP_TARGET_KEY);
+        if (object instanceof DropTarget)
+            return (DropTarget) object;
+        return null;
+    }
+
+    @Override
+    public final void dragEnter(DropTargetEvent e)
+    {
+        updateDragDetails(e);
+    }
+
+    @Override
+    public final void dragOver(DropTargetEvent e)
+    {
+        updateDragDetails(e);
+    }
+
+    @Override
+    public final void dragLeave(DropTargetEvent e)
+    {
+        if (e.detail == DND.DROP_NONE)
+            setDropOperation(e);
+    }
+
+    @Override
+    public final void dropAccept(DropTargetEvent e)
+    {
+        updateDragDetails(e);
+    }
+
+    @Override
+    public final void dragOperationChanged(DropTargetEvent e)
+    {
+        updateDragDetails(e);
+    }
+
+    private final void setDropOperation(DropTargetEvent e)
+    {
+        int allowedOperations = e.operations;
+        for (int op : new int[] { DND.DROP_DEFAULT, DND.DROP_COPY, DND.DROP_MOVE, DND.DROP_LINK })
+        {
+            if ((allowedOperations & op) != 0)
+            {
+                e.detail = op;
+                return;
+            }
+        }
+        e.detail = allowedOperations;
+    }
+
+    private final void updateDragDetails(DropTargetEvent e)
+    {
+        if (isValidEvent(e))
+            setDropOperation(e);
+    }
+
+    protected boolean isValidEvent(DropTargetEvent e)
+    {
+        return this.transfer.isSupportedType(e.currentDataType);
+    }
+
+    @Override
+    public final void drop(DropTargetEvent event)
+    {
+        if (!this.transfer.isSupportedType(event.currentDataType))
+            return;
+
+        if (event.data == null)
+        {
+            event.detail = DND.DROP_NONE;
+            return;
+        }
+
+        if (!isValidEvent(event))
+        {
+            event.detail = DND.DROP_NONE;
+            return;
+        }
+
+        doDrop(event);
+    }
+
+    protected abstract void doDrop(DropTargetEvent event);
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/ImportFromFileDropAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/ImportFromFileDropAdapter.java
@@ -1,0 +1,89 @@
+package name.abuchen.portfolio.ui.dnd;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.wizard.WizardDialog;
+import org.eclipse.swt.dnd.DND;
+import org.eclipse.swt.dnd.DropTarget;
+import org.eclipse.swt.dnd.DropTargetEvent;
+import org.eclipse.swt.dnd.FileTransfer;
+import org.eclipse.swt.dnd.Transfer;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Display;
+
+import name.abuchen.portfolio.ui.editor.PortfolioPart;
+import name.abuchen.portfolio.ui.handlers.ImportPDFHandler;
+import name.abuchen.portfolio.ui.util.swt.ActiveShell;
+import name.abuchen.portfolio.ui.wizards.datatransfer.CSVImportWizard;
+
+public class ImportFromFileDropAdapter extends AbstractDropAdapter
+{
+    private static final Pattern PDF_FILE = Pattern.compile(".*\\.pdf$", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$
+    private static final Pattern CSV_FILE = Pattern.compile(".*\\.csv$", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$
+
+    private final PortfolioPart part;
+
+    private ImportFromFileDropAdapter(Transfer transfer, Control control, PortfolioPart part)
+    {
+        super(transfer, control);
+        this.part = part;
+    }
+
+    public static void attach(Control control, PortfolioPart part)
+    {
+        new ImportFromFileDropAdapter(FileTransfer.getInstance(), control, part);
+    }
+
+    @Override
+    public void doDrop(DropTargetEvent event)
+    {
+        String[] files = (String[]) event.data;
+        if (files.length == 0)
+        {
+            event.detail = DND.DROP_NONE;
+            return;
+        }
+
+        if (PDF_FILE.matcher(files[0]).matches())
+        {
+            openPDFImport(event, files);
+        }
+        else if (CSV_FILE.matcher(files[0]).matches())
+        {
+            openCSVImport(event, files);
+        }
+        else
+        {
+            event.detail = DND.DROP_NONE;
+        }
+    }
+
+    private void openPDFImport(DropTargetEvent event, String[] fileNames)
+    {
+        List<File> files = new ArrayList<>();
+        for (String f : fileNames)
+            files.add(new File(f));
+
+        DropTarget source = (DropTarget) event.getSource();
+        Display display = source.getDisplay();
+        display.asyncExec(() -> ImportPDFHandler.runImportWithFiles(part, ActiveShell.get(), part.getClient(), null,
+                        null, files));
+    }
+
+    private void openCSVImport(DropTargetEvent event, String[] fileNames)
+    {
+        DropTarget source = (DropTarget) event.getSource();
+        Display display = source.getDisplay();
+        display.asyncExec(() -> {
+            CSVImportWizard wizard = new CSVImportWizard(part.getClient(), part.getPreferenceStore(),
+                            new File(fileNames[0]));
+            part.inject(wizard);
+            Dialog wizwardDialog = new WizardDialog(ActiveShell.get(), wizard);
+            wizwardDialog.open();
+        });
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/ImportFromURLDropAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/ImportFromURLDropAdapter.java
@@ -38,8 +38,7 @@ import name.abuchen.portfolio.ui.wizards.security.EditSecurityDialog;
 
 public class ImportFromURLDropAdapter extends AbstractDropAdapter
 {
-    private static final Pattern URL_PATTERN = Pattern
-                    .compile("^https://www.portfolio-report.net/securities/([^/]+)/?"); //$NON-NLS-1$
+    public static final Pattern URL_PATTERN = Pattern.compile("^https://www.portfolio-report.net/securities/([^/]+)/?"); //$NON-NLS-1$
 
     private final PortfolioPart part;
 

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/ImportFromURLDropAdapter.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/dnd/ImportFromURLDropAdapter.java
@@ -1,9 +1,8 @@
-package name.abuchen.portfolio.ui.util;
+package name.abuchen.portfolio.ui.dnd;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,7 +13,6 @@ import org.eclipse.jface.util.Util;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.dnd.DND;
 import org.eclipse.swt.dnd.DropTarget;
-import org.eclipse.swt.dnd.DropTargetAdapter;
 import org.eclipse.swt.dnd.DropTargetEvent;
 import org.eclipse.swt.dnd.Transfer;
 import org.eclipse.swt.dnd.TransferData;
@@ -34,88 +32,32 @@ import name.abuchen.portfolio.online.impl.PortfolioReportNet;
 import name.abuchen.portfolio.online.impl.PortfolioReportQuoteFeed;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.PortfolioPlugin;
-import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
+import name.abuchen.portfolio.ui.editor.PortfolioPart;
 import name.abuchen.portfolio.ui.jobs.UpdateQuotesJob;
 import name.abuchen.portfolio.ui.wizards.security.EditSecurityDialog;
 
-// inspired by the Eclipse Marketplace Client
-// https://github.com/eclipse/epp.mpc/blob/master/org.eclipse.epp.mpc.ui/src/org/eclipse/epp/internal/mpc/ui/wizards/MarketplaceDropAdapter.java
-public class CreateSecurityFromURLDropAdaptor extends DropTargetAdapter
+public class ImportFromURLDropAdapter extends AbstractDropAdapter
 {
     private static final Pattern URL_PATTERN = Pattern
                     .compile("^https://www.portfolio-report.net/securities/([^/]+)/?"); //$NON-NLS-1$
 
-    private final AbstractFinanceView view;
+    private final PortfolioPart part;
 
-    private CreateSecurityFromURLDropAdaptor(AbstractFinanceView owner)
+    private ImportFromURLDropAdapter(Transfer transfer, Control control, PortfolioPart part)
     {
-        this.view = Objects.requireNonNull(owner);
+        super(transfer, control);
+        this.part = part;
     }
 
-    public static void attach(AbstractFinanceView view, Control control)
+    public static void attach(Control control, PortfolioPart part)
     {
-        Transfer[] transferAgents = new Transfer[] { URLTransfer.getInstance() };
-
-        DropTarget dropTarget = new DropTarget(control,
-                        DND.DROP_MOVE | DND.DROP_COPY | DND.DROP_LINK | DND.DROP_DEFAULT);
-        dropTarget.setTransfer(transferAgents);
-        dropTarget.addDropListener(new CreateSecurityFromURLDropAdaptor(view));
+        new ImportFromURLDropAdapter(URLTransfer.getInstance(), control, part);
     }
 
     @Override
-    public void dragEnter(DropTargetEvent e)
+    protected boolean isValidEvent(DropTargetEvent e)
     {
-        updateDragDetails(e);
-    }
-
-    @Override
-    public void dragOver(DropTargetEvent e)
-    {
-        updateDragDetails(e);
-    }
-
-    @Override
-    public void dragLeave(DropTargetEvent e)
-    {
-        if (e.detail == DND.DROP_NONE)
-            setDropOperation(e);
-    }
-
-    @Override
-    public void dropAccept(DropTargetEvent e)
-    {
-        updateDragDetails(e);
-    }
-
-    @Override
-    public void dragOperationChanged(DropTargetEvent e)
-    {
-        updateDragDetails(e);
-    }
-
-    private void setDropOperation(DropTargetEvent e)
-    {
-        int allowedOperations = e.operations;
-        for (int op : new int[] { DND.DROP_DEFAULT, DND.DROP_COPY, DND.DROP_MOVE, DND.DROP_LINK })
-        {
-            if ((allowedOperations & op) != 0)
-            {
-                e.detail = op;
-                return;
-            }
-        }
-        e.detail = allowedOperations;
-    }
-
-    private void updateDragDetails(DropTargetEvent e)
-    {
-        if (isValidEvent(e))
-            setDropOperation(e);
-    }
-
-    private boolean isValidEvent(DropTargetEvent e)
-    {
-        if (!URLTransfer.getInstance().isSupportedType(e.currentDataType))
+        if (!super.isValidEvent(e))
             return false;
 
         if (Util.isWindows())
@@ -146,22 +88,8 @@ public class CreateSecurityFromURLDropAdaptor extends DropTargetAdapter
     }
 
     @Override
-    public void drop(DropTargetEvent event)
+    public void doDrop(DropTargetEvent event)
     {
-        if (!URLTransfer.getInstance().isSupportedType(event.currentDataType))
-            return;
-        if (event.data == null)
-        {
-            event.detail = DND.DROP_NONE;
-            return;
-        }
-
-        if (!isValidEvent(event))
-        {
-            event.detail = DND.DROP_NONE;
-            return;
-        }
-
         Optional<String> url = getUrlFromEvent(event);
         if (!url.isPresent())
         {
@@ -218,13 +146,13 @@ public class CreateSecurityFromURLDropAdaptor extends DropTargetAdapter
                                 exchanges.get(0).getId());
             }
 
-            Dialog dialog = view.make(EditSecurityDialog.class, newSecurity);
+            Dialog dialog = part.make(EditSecurityDialog.class, newSecurity);
 
             if (dialog.open() == Window.OK)
             {
-                view.getClient().addSecurity(newSecurity);
+                part.getClient().addSecurity(newSecurity);
 
-                new UpdateQuotesJob(view.getClient(), newSecurity).schedule();
+                new UpdateQuotesJob(part.getClient(), newSecurity).schedule();
             }
         }
         catch (IOException e)

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientEditorSidebar.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/ClientEditorSidebar.java
@@ -18,6 +18,8 @@ import org.eclipse.swt.widgets.Control;
 import name.abuchen.portfolio.model.Security;
 import name.abuchen.portfolio.model.Watchlist;
 import name.abuchen.portfolio.ui.Images;
+import name.abuchen.portfolio.ui.dnd.ImportFromFileDropAdapter;
+import name.abuchen.portfolio.ui.dnd.ImportFromURLDropAdapter;
 import name.abuchen.portfolio.ui.dnd.SecurityTransfer;
 import name.abuchen.portfolio.ui.editor.Navigation.Item;
 import name.abuchen.portfolio.ui.editor.Navigation.Tag;
@@ -106,6 +108,10 @@ import name.abuchen.portfolio.ui.editor.Navigation.Tag;
         };
         editor.getClientInput().getNavigation().addListener(listener);
         sidebar.addDisposeListener(e -> editor.getClientInput().getNavigation().removeListener(listener));
+
+        ImportFromURLDropAdapter.attach(sidebar, editor);
+
+        ImportFromFileDropAdapter.attach(sidebar, editor);
 
         return scrolledComposite;
     }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/editor/PortfolioPart.java
@@ -543,12 +543,17 @@ public class PortfolioPart implements ClientInputListener
         }
     }
 
-    private <T> T make(Class<T> type, Object... parameters)
+    public <T> T make(Class<T> type, Object... parameters)
     {
         IEclipseContext c2 = EclipseContextFactory.create();
         if (parameters != null)
             for (Object param : parameters)
                 c2.set(param.getClass().getName(), param);
         return ContextInjectionFactory.make(type, this.context, c2);
+    }
+
+    public void inject(Object object)
+    {
+        ContextInjectionFactory.inject(object, context);
     }
 }

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/handlers/ImportPDFHandler.java
@@ -75,6 +75,12 @@ public class ImportPDFHandler
         for (String filename : filenames)
             files.add(new File(fileDialog.getFilterPath(), filename));
 
+        runImportWithFiles(part, shell, client, account, portfolio, files);
+    }
+
+    public static void runImportWithFiles(PortfolioPart part, Shell shell, Client client, Account account,
+                    Portfolio portfolio, List<File> files)
+    {
         IPreferenceStore preferences = part.getPreferenceStore();
 
         try

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages.properties
@@ -1155,6 +1155,8 @@ LabelLevelNameNumber = {0} (Level {1})
 
 LabelLevelNumber = Level {0}
 
+LabelLinkToPortfolioReportNet = Link to Portfolio Report
+
 LabelLinkedToPortfolioReport = Linked to <a>Portfolio Report</a>
 
 LabelMaxDrawdown = Maximum Drawdown

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_de.properties
@@ -1151,6 +1151,8 @@ LabelLevelNameNumber = {0} (Ebene {1})
 
 LabelLevelNumber = Ebene {0}
 
+LabelLinkToPortfolioReportNet = Mit Portfolio Report verkn\u00FCpfen
+
 LabelLinkedToPortfolioReport = Verkn\u00FCpft mit <a>Portfolio Report</a>
 
 LabelMaxDrawdown = Maximaler Drawdown

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_es.properties
@@ -1025,6 +1025,8 @@ LabelLevelNameNumber = {0} (Nivel {1})
 
 LabelLevelNumber = Nivel {0}
 
+LabelLinkToPortfolioReportNet = Enlace con Portfolio Report
+
 LabelLinkedToPortfolioReport = Vinculado al <a>Portfolio Report</a>
 
 LabelMaxDrawdown = Drawdown m\u00E1ximo

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_nl.properties
@@ -1147,6 +1147,8 @@ LabelLevelNameNumber = {0} (Niveau {1})
 
 LabelLevelNumber = Niveau {0}
 
+LabelLinkToPortfolioReportNet = Link met Portfolio Report
+
 LabelLinkedToPortfolioReport = Gekoppeld aan <a>Portfolio Report</a>
 
 LabelMaxDrawdown = Maximale daling

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/messages_pt.properties
@@ -1153,6 +1153,8 @@ LabelLevelNameNumber = {0} (N\u00EDvel {1})
 
 LabelLevelNumber = Level {0}
 
+LabelLinkToPortfolioReportNet = Vincule com o Portfolio Report
+
 LabelLinkedToPortfolioReport = Vinculado ao <a>Portfolio Report</a>
 
 LabelMaxDrawdown = Drawdown m\u00E1ximo

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ActiveShell.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/util/swt/ActiveShell.java
@@ -1,0 +1,40 @@
+package name.abuchen.portfolio.ui.util.swt;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+/**
+ * Keep a reference to the last active shell in case the RCP application has no
+ * focus at the moment. Use case: user drag and drops files to PP which
+ * currently has not the focus (instead Finder or Windows Explorer have the
+ * focus). See // https://stackoverflow.com/a/28986616/1158146
+ */
+public class ActiveShell
+{
+    private static final ActiveShell activeShell = new ActiveShell();
+
+    private Shell shell;
+
+    public ActiveShell()
+    {
+        Display display = Display.getCurrent();
+
+        shell = display.getActiveShell();
+
+        display.addFilter(SWT.Activate, e -> {
+            if (e.widget instanceof Shell)
+                shell = (Shell) e.widget;
+        });
+    }
+
+    public static Shell get()
+    {
+        return activeShell.getShell();
+    }
+
+    private Shell getShell()
+    {
+        return shell;
+    }
+}

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -59,6 +59,8 @@ import name.abuchen.portfolio.ui.dialogs.transactions.InvestmentPlanDialog;
 import name.abuchen.portfolio.ui.dialogs.transactions.OpenDialogAction;
 import name.abuchen.portfolio.ui.dialogs.transactions.SecurityTransactionDialog;
 import name.abuchen.portfolio.ui.dialogs.transactions.SecurityTransferDialog;
+import name.abuchen.portfolio.ui.dnd.ImportFromFileDropAdapter;
+import name.abuchen.portfolio.ui.dnd.ImportFromURLDropAdapter;
 import name.abuchen.portfolio.ui.dnd.SecurityDragListener;
 import name.abuchen.portfolio.ui.dnd.SecurityTransfer;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
@@ -66,7 +68,6 @@ import name.abuchen.portfolio.ui.jobs.UpdateQuotesJob;
 import name.abuchen.portfolio.ui.util.BookmarkMenu;
 import name.abuchen.portfolio.ui.util.Colors;
 import name.abuchen.portfolio.ui.util.ConfirmActionWithSelection;
-import name.abuchen.portfolio.ui.util.CreateSecurityFromURLDropAdaptor;
 import name.abuchen.portfolio.ui.util.viewers.BooleanEditingSupport;
 import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport;
@@ -119,7 +120,8 @@ public final class SecuritiesTable implements ModificationListener
 
         this.securities = new TableViewer(container, SWT.FULL_SELECTION | SWT.MULTI);
 
-        CreateSecurityFromURLDropAdaptor.attach(this.view, this.securities.getControl());
+        ImportFromURLDropAdapter.attach(this.securities.getControl(), view.getPart());
+        ImportFromFileDropAdapter.attach(this.securities.getControl(), view.getPart());
 
         ColumnEditingSupport.prepare(securities);
         ColumnViewerToolTipSupport.enableFor(securities, ToolTip.NO_RECREATE);

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/SecuritiesTable.java
@@ -1,5 +1,6 @@
 package name.abuchen.portfolio.ui.views;
 
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
 import org.eclipse.jface.action.Action;
@@ -16,6 +18,7 @@ import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.MenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.InputDialog;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.layout.TableColumnLayout;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -50,6 +53,8 @@ import name.abuchen.portfolio.model.Watchlist;
 import name.abuchen.portfolio.money.Values;
 import name.abuchen.portfolio.online.Factory;
 import name.abuchen.portfolio.online.QuoteFeed;
+import name.abuchen.portfolio.online.SecuritySearchProvider.ResultItem;
+import name.abuchen.portfolio.online.impl.PortfolioReportNet;
 import name.abuchen.portfolio.snapshot.QuoteQualityMetrics;
 import name.abuchen.portfolio.snapshot.ReportingPeriod;
 import name.abuchen.portfolio.ui.Images;
@@ -91,6 +96,55 @@ import name.abuchen.portfolio.util.Pair;
 
 public final class SecuritiesTable implements ModificationListener
 {
+    private class LinkToPortfolioReport extends Action
+    {
+        private Security security;
+
+        public LinkToPortfolioReport(Security security)
+        {
+            super(Messages.LabelLinkToPortfolioReportNet);
+            this.security = security;
+        }
+
+        @Override
+        public void run()
+        {
+            InputDialog dlg = new InputDialog(Display.getCurrent().getActiveShell(), Messages.LabelInfo,
+                            "Portfolio Report URL", "https://www.portfolio-report.net/", //$NON-NLS-1$//$NON-NLS-2$
+                            newText -> ImportFromURLDropAdapter.URL_PATTERN.matcher(newText).matches() ? null
+                                            : MessageFormat.format(Messages.DesktopAPIIllegalURL, newText));
+            if (dlg.open() != Window.OK)
+                return;
+
+            String url = dlg.getValue();
+
+            Matcher matcher = ImportFromURLDropAdapter.URL_PATTERN.matcher(url);
+            if (!matcher.matches())
+                return;
+
+            String onlineId = matcher.group(1);
+
+            try
+            {
+                Optional<ResultItem> result = new PortfolioReportNet().getUpdatedValues(onlineId);
+                if (!result.isPresent())
+                {
+                    MessageDialog.openError(Display.getDefault().getActiveShell(), Messages.LabelError,
+                                    MessageFormat.format(Messages.MsgErrorNoInvestmentVehicleFoundAtURL, url));
+                }
+                else
+                {
+                    security.setOnlineId(onlineId);
+                    PortfolioReportNet.updateWith(security, result.get());
+                }
+            }
+            catch (IOException e)
+            {
+                MessageDialog.openError(Display.getDefault().getActiveShell(), Messages.LabelError, e.getMessage());
+            }
+        }
+    }
+
     private AbstractFinanceView view;
 
     private Watchlist watchlist;
@@ -800,6 +854,12 @@ public final class SecuritiesTable implements ModificationListener
 
             manager.add(new Separator());
             manager.add(new BookmarkMenu(view.getPart(), security));
+
+            if (security.getOnlineId() == null)
+            {
+                manager.add(new Separator());
+                manager.add(new LinkToPortfolioReport(security));
+            }
         }
 
         manager.add(new Separator());

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/StatementOfAssetsViewer.java
@@ -74,13 +74,14 @@ import name.abuchen.portfolio.snapshot.security.SecurityPerformanceSnapshot;
 import name.abuchen.portfolio.ui.Images;
 import name.abuchen.portfolio.ui.Messages;
 import name.abuchen.portfolio.ui.UIConstants;
+import name.abuchen.portfolio.ui.dnd.ImportFromFileDropAdapter;
+import name.abuchen.portfolio.ui.dnd.ImportFromURLDropAdapter;
 import name.abuchen.portfolio.ui.dnd.SecurityDragListener;
 import name.abuchen.portfolio.ui.dnd.SecurityTransfer;
 import name.abuchen.portfolio.ui.editor.AbstractFinanceView;
 import name.abuchen.portfolio.ui.selection.SecuritySelection;
 import name.abuchen.portfolio.ui.selection.SelectionService;
 import name.abuchen.portfolio.ui.util.AttributeComparator;
-import name.abuchen.portfolio.ui.util.CreateSecurityFromURLDropAdaptor;
 import name.abuchen.portfolio.ui.util.LabelOnly;
 import name.abuchen.portfolio.ui.util.viewers.Column;
 import name.abuchen.portfolio.ui.util.viewers.ColumnEditingSupport;
@@ -183,7 +184,8 @@ public class StatementOfAssetsViewer
         ColumnViewerToolTipSupport.enableFor(assets, ToolTip.NO_RECREATE);
         ColumnEditingSupport.prepare(assets);
 
-        CreateSecurityFromURLDropAdaptor.attach(this.owner, this.assets.getControl());
+        ImportFromURLDropAdapter.attach(this.assets.getControl(), owner.getPart());
+        ImportFromFileDropAdapter.attach(this.assets.getControl(), owner.getPart());
 
         assets.addSelectionChangedListener(event -> {
             Element element = (Element) ((IStructuredSelection) event.getSelection()).getFirstElement();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/online/impl/GenericJSONQuoteFeed.java
@@ -177,6 +177,8 @@ public final class GenericJSONQuoteFeed implements QuoteFeed
                     price.setDate(parseDateTimestamp((Long) object));
                 else if (object instanceof Integer)
                     price.setDate(parseDateTimestamp(Long.valueOf((Integer) object)));
+                else if (object instanceof Double)
+                    price.setDate(parseDateTimestamp(((Double) object).longValue()));
                 else if (object instanceof LocalDate)
                     price.setDate((LocalDate) object);
 

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/security/DividendCalculation.java
@@ -120,12 +120,14 @@ import name.abuchen.portfolio.util.Dates;
         }
 
         int years = 0;
+        
         // now walk through individual years
         for (int year = firstPayment.getYear(); year <= lastPayment.getYear(); year++)
         {
             years++;
             int countPerYear = 0;
             long sumPerYear = 0;
+            LocalDate lastDate = null;
 
             // first calc sum only for this year
             for (DividendPayment p : payments)
@@ -146,7 +148,7 @@ import name.abuchen.portfolio.util.Dates;
 
             // calc expected amount for this year
             double expectedAmount = sumPerYear / (double) countPerYear;
-
+            
             // then calc significance
             for (DividendPayment p : payments)
             {
@@ -158,8 +160,14 @@ import name.abuchen.portfolio.util.Dates;
                     double significance = p.amount.getAmount() / expectedAmount;
                     if (significance > 0.3)
                     {
-                        significantCount++;
+                        // check, if dividends were recorded for multiple
+                        // accounts at the same date
+                        if (lastDate == null || !p.date.equals(lastDate))
+                        {
+                            significantCount++;
+                        }
                     }
+                    lastDate = p.date;
                 }
             }
         }


### PR DESCRIPTION
Bisher konnten nur Abrechnungen importiert werden, wo der Wertpapiername den Textbestandteil "Inhaber-Anteile" hat. Bei McDonald's funktionierte es nicht mehr. Dafür habe ich die regulären Ausdrucke angepasst. Ich konnte allerdings keinen Verkauf testen.
Die Änderung ist nicht abwärtskompatibel, da jetzt "Inhaber-Anteile" mit als Namensbestandteil importiert wird.
Ein weiteres Problem waren Dividenden in US-Dollar - auch hier konnte ich den regulären Ausdruck anpassen.
Ich habe vorhandene Unit-Tests angepasst und zwei neue erstellt.

Für spätere Abrechnungen (spätestens ab Oktober 2015) muss der PDF-Text-Konverter (pdfbox) aktualisiert werden.

